### PR TITLE
Starting to fix issue#4

### DIFF
--- a/Programming/RepyV2API.md
+++ b/Programming/RepyV2API.md
@@ -1,0 +1,1213 @@
+# Repy V2 Library Reference
+----
+
+For a detailed description of Network API call semantics see: [NetworkApiSemantics](https://github.com/SeattleTestbed/docs/blob/master/UnderstandingSeattle/NetworkApiSemantics.md).  (Read the description of calls on this page first.)
+I have made the following resource consumption simplifications to make the interface easier to understand:
+ * I assume that the minimum packet size is 64 bytes and all data consumes extra space.   This unfairly penalizes small packets.
+ * I assume there is no maximum packet size.   This slightly benefits large packets / messages / sends.
+ * I assume that every separate network API call will result in a separate packet.   This presumes no 'batching' occurs.
+ * I assume that every disk I/O operation touches a separate block.
+ * I assume that a disk block has size 4K.
+ * I assume that every chunk of file data is aligned on 4K intervals.   This means that small reads / writes may cross blocks if they are done at 4K boundaries.
+ * I assume that each file that is created results in 4K of space and disk I/O.
+
+For more information on the Exception hierarchy for Repy 2.0, see FutureRepyExceptions.
+
+If multiple exceptions should occur for a given operation, the exception listed first in the doc string will happen.   For example, if openfile is called on an invalid filename when there are no available file handle resources, RepyArgumentError will occur instead of ResourceExhaustedError.
+
+## Introduction and Purpose
+----
+This document describes the narrow API available to repy programs.   This document includes all of the calls that are available to a repy program and the use and meaning of these calls.   For items built into the python programming language (like list operations, etc.) see the appropriate Python documentation.   
+
+The intent is that we will build libraries that will provide 'rich' functionality on top of these abstractions.   For example, the file-like objects don't support next, but we can build this in a library.   Also, notice that the logging mechanism doesn't support multiple arguments / do type conversion.   We can do this in a user level library.   We will expect that all users will load this library (and may even do it for them).
+
+## Cheat Sheet
+----
+|Variable Name|Short description|Tutorial Section|
+|-------------|-----------------|----------------|
+|callargs|callargs are the command line arguments for your program (similar to Python's sys.argv[1:])|example 2.2|
+
+|Object Name|Short description|Tutorial Section|
+|-----------|-----------------|----------------|
+|file|similar to Python's file object|example 2.1|
+|socket|similar to Python's socket object|example 1.2|
+|lock|similar to Python's threading.Lock object|example 1.6|
+|tcpserversocket|A way to obtain incoming connections|new|
+|udpserversocket|A way to obtain incoming packets|new|
+|virtualnamespace|A way to evaluate statically analyzed code|new|
+
+|Object / Function Name|Short description|Tutorial Section|
+|----------------------|-----------------|----------------|
+|file.readat|Read data from a file (maybe seek first).|N/A (new call)|
+|file.writeat|Write data to a file (maybe seek first).|N/A (new call)|
+|file.close|Close an open file.|example 2.1|
+|socket.recv|Read data from a socket in a non-blocking manner|example 1.2|
+|socket.send|Send data on a socket in a non-blocking manner|example 1.2|
+|socket.close|Closes a socket|example 3.2|
+|lock.acquire|Acquire the lock|example 1.6|
+|lock.release|Release the lock|example 1.6|
+|tcpserversocket.getconnection|Returns a socket from a new connection| N/A (new call)|
+|tcpserversocket.close|Stops listening for connections| new call|
+|udpserversocket.getmessage|Returns a UDP packet| N/A (new call)|
+|udpserversocket.close|Stops listening for connections| new call|
+|virtualnamespace.evaluate|Evaluates the code in a given global context|new call|
+
+|Function Name|Short description|Tutorial Section|
+|-------------|-----------------|----------------|
+|openfile|opens file objects. |example 2.1|
+|listfiles|Returns a list of file names for the files in the VM|example 2.2|
+|removefile|similar to Python's os.remove() function|example 2.2|
+|sleep|similar to Python's time.sleep() function|example 1.6|
+|randombytes|similar to Python's os.urandom() function|(new call) example 4.2|
+|createlock|similar to Python's threading.Lock() constructor|example 1.6|
+|exitall|similar to Python's sys.exit() or os._exit()|example 3.2|
+|getruntime|gets the time since the program was started|example 1.4|
+|gethostbyname|similar to Python's socket.gethostbyname() function|example 4.1|
+|getmyip|gets an external IP address of the computer|example 4.1|
+|sendmessage|sends a message to another computer|example 4.2|
+|openconnection|opens a connection to another computer|example 3.1|
+|listenforconnection|return a tcpserversocket that can be used to accept incoming connections|new|
+|listenformessage|return a udpserversocket that can be used to accept incoming messages|new|
+|createthread|creates a new thread to execute a function|new (example 1.4)|
+|getthreadname|provides a unique string that indicates the name of the current thread|New call|
+|createvirtualnamespace|Provides a virtualnamespace object that can be used to evaluate code|New call|
+|getresources|Provides two dictionaries which represent the resource limits and usage and an array of stoptimes|New call|
+|getlasterror|Obtain information about the last error (exception) that occurred in the current thread.|New call|
+
+## Detailed description
+----
+### Shared variables
+----
+#### mycontext
+----
+Mycontext is a dictionary that is shared between all of the threads in your program. The intent is that mycontext will be used in the place of global variables. See the tutorial for examples using mycontext.
+
+### API functions
+----
+#### Network functions
+##### gethostbyname(name)
+----
+(from the Python documentation)   Translate a host name to IPv4 address format. The IPv4 address is returned as a string, such as '100.50.200.5'. If the host name is an IPv4 address itself it is returned unchanged.
+
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Provides information about a hostname. Calls socket.gethostbyname().
+    Translates a hostname to IPv4 address format. The IPv4 address is
+    returned as a string, such as '100.50.200.5'. If the host name is an
+    IPv4 address itself it is returned unchanged.
+
+  <Arguments>
+    name:
+       The host name to translate.
+
+  <Exceptions>
+    RepyArgumentError (descends from NetworkError) if the name is not a string
+
+    NetworkAddressError (descends from NetworkError) if the address cannot
+    be resolved.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    This operation consumes network bandwidth of 4K netrecv, 1K netsend.
+    (It's hard to tell how much was actually sent / received at this level.)
+
+  <Returns>
+    The IPv4 address as a string.
+"""
+```
+
+##### getmyip()
+----
+Returns the localhost's "Internet facing" IP address.   If there are multiple interfaces, this IP will be on the interface that will be used by default to handle traffic to Internet hosts.   Note that if the node is behind a NAT or similar, this may be a private IP.  It may raise an exception on hosts that are not connected to the Internet.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Provides the IP of this computer on its public facing interface.   Does some clever trickery.
+
+  <Arguments>
+    None
+
+  <Exceptions>
+    InternetConnectivityError if the host is not connected to the internet.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    This operations consumes 256 netsend and 128 netrecv.
+
+  <Returns>
+    The localhost's IP address
+"""
+```
+
+##### sendmessage(destip, destport, message, localip, localport)
+----
+(rename of ~~sendmess~~)
+
+Sends a UDP message to a destination host / port using a specified localip and localport.   Returns the number of bytes sent.   **This may not be the entire message**
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Send a message to a host / port
+
+  <Arguments>
+    destip:
+       The IP to send the message to
+    destport:
+       The port to send the message to
+    message:
+       The message to send
+    localip:
+       The local IP to send the message from 
+    localport:
+       The local port to send the message from
+
+  <Exceptions>
+    AddressBindingError (descends NetworkError) when the local IP isn't
+      a local IP.
+
+    ResourceForbiddenError (descends ResourceException) when the local
+      port isn't allowed
+
+    RepyArgumentError when the local IP and port aren't valid types
+      or values
+
+    AlreadyListeningError if there is an existing listening UDP socket
+    on the same local IP and port.
+
+    DuplicateTupleError if there is another sendmessage on the same
+    local IP and port to the same remote host.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    This operation consumes 64 bytes + number of bytes of the message that
+    were transmitted. This requires that the localport is allowed.
+
+  <Returns>
+    The number of bytes sent on success
+"""
+```
+ 
+##### openconnection(destip, destport, localip, localport, timeout)
+----
+(rename of ~~openconn~~)
+
+Open a TCP connection to a remote computer, returning a socket object.   There is a timeout value that can be set to limit the amount of time the system will wait for a response before abandoning the attempt to connect.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Opens a connection, returning a socket-like object
+
+
+  <Arguments>
+    destip: The destination ip to open communications with
+
+    destport: The destination port to use for communication
+
+    localip: The local ip to use for the communication
+
+    localport: The local port to use for communication
+
+    timeout: The maximum amount of time (in seconds) to wait to connect.   This may
+             be a floating point number or an integer
+
+
+  <Exceptions>
+
+    RepyArgumentError if the arguments are invalid.   This includes both
+    the types and values of arguments. If the localip matches the destip,
+    and the localport matches the destport this will also be raised.
+
+    AddressBindingError (descends NetworkError) if the localip isn't 
+    associated with the local system or is not allowed.
+
+    ResourceForbiddenError (descends ResourceError) if the localport isn't 
+    allowed.
+
+    DuplicateTupleError (descends NetworkError) if the (localip, localport, 
+    destip, destport) tuple is already used.   This will also occur if the 
+    operating system prevents the local IP / port from being used.
+
+    AlreadyListeningError if the (localip, localport) tuple is already used
+    for a listening TCP socket.
+
+    CleanupInProgressError if the (localip, localport, destip, destport) tuple is
+    still being cleaned up by the OS.
+
+    ConnectionRefusedError (descends NetworkError) if the connection cannot 
+    be established because the destination port isn't being listened on.
+
+    TimeoutError (common to all API functions that timeout) if the 
+    connection times out
+
+    InternetConnectivityError if the network is down, or if the host
+    cannot be reached from the local IP that has been bound to.
+
+  <Resource Consumption>
+    This operation consumes 64*2 bytes of netsend (SYN, ACK) and 64 bytes 
+    of netrecv (SYN/ACK). This requires that the localport is allowed. Upon 
+    success, this call consumes an outsocket.
+
+  <Returns>
+    A socket-like object that can be used for communication. Use send, 
+    recv, and close just like you would an actual socket object in python.
+"""
+```
+
+##### socket.close()
+----
+Closes the socket.   Any further local calls to recv / send will result in an exception.
+
+ * Doc string:
+```python
+"""
+    <Purpose>
+    Closes a socket.   Pending remote recv() calls will return with the 
+    remaining information.   Local recv / send calls will fail after this.
+
+  <Arguments>
+    None
+
+  <Exceptions>
+    None
+
+  <Side Effects>
+    Pending local recv calls will either return or have an exception.
+
+  <Resource Consumption>
+    If the connection is closed, no resources are consumed. This operation
+    uses 64 bytes of netrecv, and 128 bytes of netsend.
+    This call also stops consuming an outsocket.
+
+  <Returns>
+    True if this is the first close call to this socket, False otherwise.
+"""
+```
+
+##### socket.recv(numbytes)
+----
+Receives data that was sent by the connected party using send.   Note that this may return less than `numbytes` worth of data.  Also, note that if the other party does ```s.send('hello'); s.send('Guten Tag')```, the party who calls recv may get `'helloGuten Tag'`, `'h'`, or any other prefix of the total data.   
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Receives data from a socket.   It may receive fewer bytes than 
+    requested.   
+
+  <Arguments>
+    numbytes: 
+       The maximum number of bytes to read; must be at least 1.
+
+  <Exceptions>
+    SocketClosedLocal is raised if the socket was closed locally.
+
+    SocketClosedRemote is raised if the socket was closed remotely.
+
+    SocketWouldBlockError is raised if the socket operation would block.
+
+    RepyArgumentError if `numbytes` is less than 1, not an `int`, or missing.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumptions>
+    This operations consumes 64 + amount of data  in bytes
+    worth of netrecv, and 64 bytes of netsend.
+
+  <Returns>
+    The data received from the socket (as a string).
+"""
+```
+ 
+##### socket.send(message)
+----
+Sends data to the connected party.   Note that this may send less than the entire message.   If the connection is disconnected, there is no guarantee that the other party was able to recv the data.  If the other party doesn't call recv, send may raise an exception if the sender and receiver buffers fill (the buffer size is undefined).   If the other party closes the connection, send will raise an exception.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Sends data on a socket.   It may send fewer bytes than requested.   
+
+  <Arguments>
+    message:
+      The string to send.
+
+  <Exceptions>
+    SocketClosedLocal is raised if the socket is closed locally.
+
+    SocketClosedRemote is raised if the socket is closed remotely.
+
+    SocketWouldBlockError is raised if the operation would block.
+
+    RepyArgumentError if `message` is not a string, or missing.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    This operations consumes 64 + size of sent data of netsend and
+    64 bytes of netrecv.
+
+  <Returns>
+    The number of bytes sent.   Be sure not to assume this is always the 
+    complete amount!
+"""
+```
+
+##### listenforconnection(localip, localport)
+---- 
+Binds to an IP and port and waits for incoming TCP connections.  If this function is called multiple times on the same ip and port without the first tcpserversocket being closed, the second call will have an exception.  These ports are separate from the message ports and so both a message and connection listener can use the same port.   This call raises an exception instead of blocking.
+
+* Doc string: 
+```python
+"""
+  <Purpose>
+    Sets up a TCPServerSocket to recieve incoming TCP connections. 
+
+  <Arguments>
+    localip:
+        The local IP to listen on
+    localport:
+        The local port to listen on
+
+  <Exceptions>
+    Raises AlreadyListeningError if another TCPServerSocket or process has bound
+    to the provided localip and localport.
+
+    Raises DuplicateTupleError if another process has bound to the
+    provided localip and localport.
+
+    Raises RepyArgumentError if the localip or localport are invalid
+
+    Raises ResourceForbiddenError if the ip or port is not allowed.
+
+    Raises AddressBindingError if the IP address isn't a local ip.
+
+  <Side Effects>
+    The IP / Port combination cannot be used until the TCPServerSocket
+    is closed.
+
+  <Resource Consumption>
+    Uses an insocket for the TCPServerSocket.
+
+  <Returns>
+    A TCPServerSocket object.
+"""
+```
+
+##### tcpserversocket.getconnection()
+----
+Receives a connection that was initiated to an IP and port.   waitforconn can be built in a user level library on top of this.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Accepts an incoming connection to a listening TCP socket.
+
+  <Arguments>
+    None
+
+  <Exceptions>
+    Raises SocketClosedLocal if close() has been called.
+
+    Raises SocketWouldBlockError if the operation would block.
+
+    Raises ResourcesExhaustedError if there are no free outsockets.
+
+  <Resource Consumption>
+    If successful, consumes 128 bytes of netrecv (64 bytes for
+    a SYN and ACK packet) and 64 bytes of netsend (1 ACK packet).
+    Uses an outsocket.
+
+  <Returns>
+    A tuple containing: (remote ip, remote port, socket object)
+"""
+```
+ 
+##### tcpserversocket.close()
+----
+Closes the socket.   Any further local calls to getconnection will result in an exception.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Closes the listening TCP socket.
+
+  <Arguments>
+    None
+
+  <Exceptions>
+    None
+
+  <Side Effects>
+    The IP and port can be re-used after closing.
+
+  <Resource Consumption>
+    Releases the insocket used.
+
+  <Returns>
+    True, if this is the first call to close.
+    False otherwise.
+"""
+```
+ 
+##### listenformessage(localip, localport)
+---- 
+Binds to an IP and port and waits for incoming UDP messages.  If this function is called multiple times on the same ip and port without the first udpserversocket being closed, the second call will have an exception.  These ports are separate from the connection ports and so both a message and connection listener can use the same port.   This call will raise an exception if it would block.
+
+* Doc string: 
+```python
+""" 
+  <Purpose>
+      Sets up a UDPServerSocket to receive incoming UDP messages.
+
+  <Arguments>
+      localip:
+          The local IP to register the handler on.
+      localport:
+          The port to listen on.
+
+  <Exceptions>
+      DuplicateTupleError (descends NetworkError) if the port cannot be
+      listened on because some other process on the system is listening on
+      it.
+
+      AlreadyListeningError if there is already a UDPServerSocket with the same
+      IP and port.
+
+      RepyArgumentError if the port number or ip is wrong type or obviously
+      invalid.
+
+      AddressBindingError (descends NetworkError) if the IP address isn't a
+      local IP.
+
+      ResourceForbiddenError if the port is not allowed.
+
+  <Side Effects>
+      Prevents other UDPServerSockets from using this port / IP
+
+  <Resource Consumption>
+      This operation consumes an insocket and requires that the provided messport is allowed.
+
+  <Returns>
+      The UDPServerSocket.
+"""
+```
+
+##### udpserversocket.getmessage()
+----
+Receives a message that was sent to an IP and port.   recvmess can be built in a user level library on top of this.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+      Obtains an incoming message that was sent to an IP and port.
+
+  <Arguments>
+      None.
+
+  <Exceptions>
+      SocketClosedLocal if UDPServerSocket.close() was called.
+
+      Raises SocketWouldBlockError if the operation would block.
+
+  <Side Effects>
+      None
+
+  <Resource Consumption>
+      This operation consumes 64 + size of message bytes of netrecv
+
+  <Returns>
+      A tuple consisting of the remote IP, remote port, and message.
+"""
+```
+ 
+##### udpserversocket.close()
+----
+Closes the udp server socket.   Any further local calls to getmessage will result in an exception.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+      Closes a socket that is listening for messages.
+
+  <Arguments>
+      None.
+
+  <Exceptions>
+      None.
+
+  <Side Effects>
+      The IP address and port can be reused by other UDPServerSockets after
+      this.
+
+  <Resource Consumption>
+      If applicable, this operation stops consuming the corresponding
+      insocket.
+
+  <Returns>
+      True if this is the first close call to this socket, False otherwise.
+"""
+```
+
+#### File functions
+
+##### openfile(filename, create)
+----
+
+(Replaces: ~~open~~, ~~file~~.)
+
+Open a file, returning an object of the file type. 
+
+Filenames may only be in the current directory and may only contain lowercase letters, numbers, the hyphen, underscore, and period characters.  Also, filenames cannot be '.', '..', the blank string or start with a period.   There is no concept of a directory or a folder in repy.  Filenames must be no more than 120 characters long.
+
+Every file object is capable of both reading and writing. 
+
+If create is True, the file is created if it does not exist.   Neither mode truncates the file on open.
+
+```python
+"""
+ * Doc string:
+  <Purpose>
+    Allows the user program to open a file safely. 
+
+  <Arguments>
+    filename:
+      The file that should be operated on. It must not contain 
+      characters other than 'a-z0-9.-_' and cannot start with a '.' 
+      or be the empty string.
+
+    create:
+       A Boolean flag which specifies if the file should be created
+       if it does not exist.   If the file exists, this flag has no effect.
+
+  <Exceptions>
+    RepyArgumentError is raised if the filename is invalid or create is not a boolean type.
+
+    FileInUseError is raised if a handle to the file is already open.
+
+    ResourceExhaustedError is raised if there are no available file handles.
+
+    FileNotFoundError is raised if the filename is not found, and create is False.
+
+
+  <Side Effects>
+    Opens a file on disk, uses a file descriptor.
+
+  <Resource Consumption>
+    Consumes 4K of fileread. If the file does not exist, and is created, 4K of filewrite is used.
+    If a handle to the object is created, then a file descriptor is used.
+
+  <Returns>
+    A file-like object.
+"""
+```
+
+##### file.close()
+----
+
+Close the file. A closed file cannot be read or written any more. Any operation which requires that the file be open will raise a FileClosedError after the file has been closed. 
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Allows the user program to close the handle to the file.
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    FileClosedError is raised if the file is already closed.
+
+  <Resource Consumption>
+    Releases a file handle.
+
+  <Returns>
+    None.
+"""
+```
+
+##### file.readat(sizelimit, offset)
+----
+
+Seek to a location in a file and reads up to sizelimit bytes from the file, returning what is read. If sizelimit is None, the file is read to EOF.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Reads from a file handle. Reading 0 bytes informs you if you have read
+    past the end-of-file, but returns no data.
+
+  <Arguments>
+    sizelimit: 
+      The maximum number of bytes to read from the file. Reading EOF will read less. By setting this value to None, the entire file is read.
+    offset:
+      Seek to a specific absolute offset before reading.
+
+  <Exceptions>
+    RepyArgumentError is raised if the offset or size is negative.
+
+    FileClosedError is raised if the file is already closed.
+
+    SeekPastEndOfFileError is raised if trying to read past the end of the file.
+
+  <Resource Consumption>
+    Consumes 4K of fileread for each 4K aligned-block of the file read.
+    All reads will consume at least 4K.
+
+  <Returns>
+    The data that was read. This may be the empty string if we have reached the
+    end of the file, or if the sizelimit was 0.
+"""
+```
+
+##### file.writeat(data, offset)
+----
+
+Seek to the offset in the file and then write some data to a file.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Allows the user program to write data to a file.
+
+  <Arguments>
+    data:
+      The data to write
+    offset:
+      An absolute offset into the file to write
+
+  <Exceptions>
+    RepyArgumentError is raised if the offset is negative or the data is not
+    a string.
+
+    FileClosedError is raised if the file is already closed.
+
+    SeekPastEndOfFileError is raised if trying to write past the EOF.
+
+
+  <Side Effects>
+    Writes to persistent storage.
+
+  <Resource Consumption>
+    Consumes 4K of filewrite for each 4K aligned-block of the file written.
+    All writes consume at least 4K.
+
+  <Returns>
+    Nothing
+"""
+```
+
+##### listfiles()
+----
+Returns a list of file names for the files in the VM.   
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Returns a list of files accessible to the program.
+
+  <Arguments>
+    None
+
+  <Exceptions>
+    None
+
+  <Side Effects>
+    None
+
+  <Resource Consumption>
+    Consumes 4K of fileread.
+
+  <Returns>
+    A list of strings (file names)
+"""
+```
+
+
+##### removefile(filename)
+----
+Deletes a file in the VM.   If the file does not exist, an exception is raised.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Allows the user program to remove a file in their area.
+
+  <Arguments>
+    filename: the name of the file to remove.  It must not contain 
+      characters other than 'a-z0-9.-_' and cannot start with a '.' 
+      or be the empty string.
+
+  <Exceptions>
+    RepyArgumentError is raised if the filename is invalid.
+
+    FileNotFoundError is raised if the file does not exist
+
+    FileInUseError is raised if the file is already open.
+
+  <Side Effects>
+    None
+
+  <Resource Consumption>
+    Consumes 4K of fileread, and 4K of filewrite if successful.
+
+  <Returns>
+    None
+"""
+```
+
+#### Threading functions
+##### createlock()
+----
+Returns a lock object that can be used for mutual exclusion and critical section protection.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Returns a lock object to the user program.    A lock object supports
+    two functions: acquire and release.
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    The lock object.
+"""
+```
+
+##### lock.acquire(blocking)
+----
+Blocks until the lock is available, then takes it (lock is an object obtained by calling createlock()).
+
+If the "blocking" argument is False, the method returns False immediately instead of waiting to acquire the lock; if the lock is available it takes it and returns True, as if it were called with no argument.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Acquires a lock.
+
+  <Arguments>
+    blocking - if False, returns immediately instead of waiting to acquire the lock.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    Locks the object.
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    True if the lock was acquired, False otherwise.
+"""
+```
+
+##### lock.release()
+----
+Releases the lock. This call raises an exception (?) if the lock is already unlocked.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Release a lock.
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    LockDoubleReleaseError if release() is called on an unlocked lock.
+
+  <Side Effects>
+    Unlocks the object.
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    None.
+"""
+```
+
+##### createthread(function)
+----
+Armon: Removed the "args" argument. We only accept a function. If they want to call a function with arguments,
+they can define a closure around that. This simplifies the API, without sacrificing functionality.
+
+Start a new thread to call a function.   The thread is charged to your program.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Cause the execution of a function in another thread.   The current thread 
+    of execution will also proceed.
+
+  <Arguments>
+    function:
+       The function to call
+
+  <Exceptions>
+    RepyArgumentError if the function is not callable.
+
+    ResourceExhaustedError if there are no events available.
+
+  <Side Effects>
+    Starts a new thread
+
+  <Resource Consumption>
+    This operation consumes an event.
+
+  <Returns>
+    None
+"""
+```
+
+##### sleep(seconds)
+----
+
+Sleeps the current thread for some time (waits for a specific time before executing any further instructions).   This thread will not consume CPU cycles during this time.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Allow the current thread to pause execution (similar to time.sleep()).
+    This function will not return early for any reason
+
+  <Arguments>
+    seconds:
+       The number of seconds to sleep.   This can be a floating point value
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    None.
+"""
+```
+
+##### getthreadname()
+----
+(added call)
+
+Returns a unique name that indicates the thread's name.   Don't use this to derive any meaning other than string uniqueness.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Returns a string identifier for the currently executing thread.
+    This identifier is unique to this thread.
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    A string identifier.
+"""
+```
+
+  
+#### Miscellaneous functions
+##### log(*args)
+Prints output to the console
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Used to store program output. Prints output to the console by default.
+
+  <Arguments>
+    Takes a variable number of arguments to print. They are wrapped in str(), so it is not necessarily a string.
+
+  <Exceptions>
+    None
+
+  <Returns>
+    Nothing
+"""
+```
+
+
+
+##### getruntime()
+----
+Returns a float containing the number of seconds the program has been running.   This time is guaranteed to be monotonic.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Return the amount of time the program has been running.   This is in
+    wall clock time. This is guaranteed to be monotonic.
+
+  <Arguments>
+    None
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    None
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    The elapsed time as float
+"""
+```
+
+##### randombytes()
+----
+
+Returns a string of random bytes of data derived from a hardware source of randomness.   The size of the string will be equal to 1024.   It is assumed that a client library that regularly needs small amounts of random data will cache data received from this call and return smaller values.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Return a string of random bytes with length 1024
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    This function is metered because it may involve using a hardware
+    source of randomness.
+
+  <Resource Consumption>
+    This operation consumes 1024 bytes of random data.
+
+  <Returns>
+    The string of bytes.
+"""
+```
+
+##### exitall()
+----
+Terminates the program immediately.   The program will not execute the "exit" callfunc or finally blocks.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Allows the user program to stop execution of the program without
+    passing an exit to the main program or calling finally blocks.
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    There isn't a guaranteed time which this function is realized.   This means that
+    other threads may execute while this call is being processed.
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    The current thread does not resume after exit
+"""
+```
+
+##### createvirtualnamespace(code, name)
+----
+(added call)
+Wraps any arbitrary code after performing a safety evaluation. Provides a method to evaluate the code.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+   Returns a virtualnamespace object which supports evaluation of the
+   code in an arbitrary global context.
+
+  <Arguments>
+
+   code:  The string code to check for safety and store for future evaluation.
+
+   name: The name for this module. Used during initialization only, and so
+   a stack trace can show the name of the module instead of just <string>.
+
+
+  <Exceptions>
+   A CodeUnsafeError will be raised if the static code analysis fails. This can be due to unsafe constructs,
+   invalid syntax, or an evaluation timeout.
+
+  <Side Effects>
+   Other calls to createvirtualnamespace() will wait until the first completes since safety checks are performed serially.
+
+   Another process will be launched to check the code for safety. This has memory and CPU ramifications,
+   since we will not account for it's resource consumption. The memory use will likely exceed what is allowed
+   per VM, since the memory used seems to grow faster-than-linarly with respect to LOC. 
+
+   It usually takes 0.2-0.3 seconds to launch a process, pipe the code, evaluate for safety, and return.
+
+  <Resource Consumption>
+    None
+
+  <Returns>
+   A virtualnamespace object
+"""
+```
+ 
+##### virtualnamespace.evaluate(context)
+----
+(added call)
+Evaluates the code wrapped by the virtualnamespace in a given context.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Evaluates the wrapped code within a context.
+
+  <Arguments>
+    context: A global context to use when executing the code.
+    This should be a SafeDict object, but if a dict object is provided
+    it will automatically be converted to a SafeDict object.
+
+  <Exceptions>
+    A RepyArgumentError exception will be raised if the provided context is not
+    a dictionary or safe dictionary object 
+
+    ContextUnsafeError is raised if the context is a dict but cannot be converted into a SafeDict.
+
+    Any that may be raised by the code that is being evaluated.
+
+
+  <Returns>
+    The context dictionary that was used during evaluation.
+    If the context was a dict object, this will be a new
+    SafeDict object. If the context was a SafeDict object,
+    then this will return the same context object.
+"""
+```
+
+
+ 
+##### getresources()
+----
+(added call)
+Determines the resource usage limits and current usage, and provides info on the last 100 times that repy was stopped.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Returns the resource usage limits and the current usage and an array containing information about the  last 100 stoptimes.
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    Calls to this function will be serialized.
+
+  <Resource Consumption>
+    None
+
+  <Returns>
+    A tuple of  (limits, usage, stoptimes). Limits is a dictionary which contains the maximum utilization
+    of a resource. It contains all of the resources as defined in the restrictions file. The user can also
+    determine the allowed conn and mess ports by checking for their respective entries.
+
+    The usage dictionary contains the current usage of all the resources. It has all the same entries as
+    the limits dictionary, but has an additional "threadcpu" key, which is the amount of CPU time in seconds
+    the current thread has executed for.
+
+    stoptimes is an array of tuples. Each tuple contains the time that repy was stopped (WRT/ getruntime)
+    and for how many seconds it was stopped. This array holds at most the latest 100 entries.
+"""
+```
+
+ 
+##### getlasterror()
+----
+TODO: others should review this, change its name as needed, etc.
+
+ * Doc string:
+```python
+"""
+  <Purpose>
+    Obtain information about the last error (exception) that occurred in the current thread.
+
+  <Arguments>
+    None.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    None.
+
+  <Resource Consumption>
+    None.
+
+  <Returns>
+    A string with details of the last exception that occurred in the current thread, or None if there is no such exception.
+"""
+```

--- a/Programming/RepyV2Tutorial.md
+++ b/Programming/RepyV2Tutorial.md
@@ -1,0 +1,928 @@
+# Repy V2 Tutorial
+
+## Introduction
+This guide provides an introduction to using the Repy V2 sandbox environment.  It describes what restrictions are placed upon the sandboxed code with examples. At the end of reading this document you should be able to write Repy programs, manage the restrictions on programs, and understand whether Repy is appropriate for a specific task or program.
+
+It is assumed that you have a basic understanding of network programming such as socket, ports, IP addresses, and etc.  Also, a basic understanding of HTML is useful but not required.  Lastly, you need a basic understanding of the Python programming language.  If not, you might want to first read through the Python tutorial at http://www.python.org/doc/. You do not need to be a Python expert to use Repy, but as Repy is a subset of Python, being able to write a simple Python program is essential.
+
+## Installing Repy V2
+You have to install Repy V2 before starting the tutorial. Make sure you have a Git client and Python installed on your machine (Mac and many Linux boxes already ship with that).
+
+1. First, clone the newest version of Repy V2 from GitHub: ```git clone https://github.com/SeattleTestbed/repy_v2```
+2. Create a directory of your choosing, inside of which Repy V2 will live. Unix example: ```mkdir ~/testv2```
+3. Set up Repy V2: 
+ 1. ```cd repy_v2/scripts; python initialize.py``` This downloads all of Repy V2's dependencies into a folder `repy_v2/DEPENDENCIES`.
+ 2. Still from the `scripts/` directory, run ```python build.py ~/testv2``` to copy over everything Repy V2 needs to run into the `testv2` directory you created previously.
+
+<!---
+4. To run any code in Repy V2 (e.g., example.r2py), launch Repy from its directory: ```cd ~/testv2; python repy.py restrictions.test example.r2py```
+
+
+You can download Repy [here](https://seattleclearinghouse.poly.edu/download/flibble/).   
+
+If you want you can look at the installer options using the ```--usage``` option.   You can also simply install the software using the defaults.
+
+There is the link to file used in each section next to the title and also at the bottom of this tutorial.
+Here is [raw-attachment:examples.zip link] to the zip file containing all files used in this tutorial.
+All attached files work on Windows systems.
+-->
+
+
+## Executing Repy programs
+
+You can use Repy functions from an interactive Python interpreter. In your `~/testv2` directory open Python, and map the symbols from repyportability into your namespace. For example, to get a randomfloat through repy, do:
+
+```
+$ cd ~/testv2
+$ python
+Python 2.7.10 (default, Oct 23 2015, 18:05:06)
+[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
+Type "help", "copyright", "credits" or "license" for more information.
+>>> from repyportability import *
+>>> getruntime()
+4.664378881454468
+```
+
+Note that this will not provide the security and performance isolation from Repy V2. As a result, you can also do things that are not allowed in a Repy V2 sandbox.
+
+To run a sandboxed repy program from the command line, run the following with the correct values substituted:
+
+```
+python <path to repy.py> <path to restrictions file> <path to source code>
+```
+
+### File execution (example 1.1)
+----
+[restrictions.test](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/restrictions.test), [example.1.1.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.1.1.r2py)
+
+Let's start with an example `example.1.1.r2py`, which prints the string `Hello World`. The source code looks like this:
+
+```python
+log("Hello World\n")
+```
+
+Download the two files linked above to `~/testv2` and run the following command from within the directory:
+
+```
+python repy.py restrictions.test example.1.1.r2py
+```
+
+The output is the following:
+
+```python
+Hello World
+Terminated
+```
+
+"Hello World" was printed, and the last line means that the program was terminated successfully. Not all users will see "Terminated". This only shows up on some operating systems. Other operating systems may have different messages.
+
+
+<!--- 
+  REPYV2 CAN CURRENTLY ONLY BE EXECUTED LOCALLY
+#### Executing programs remotely in VMs
+----
+You can also access the resources donated to you and run the program example.1.1.r2py in the resources you can control. You need to follow the steps below in the shell in order to  run the program in resources.
+
+**Step 1. Run programs in Seattle**
+
+To run a program, you should use the experiment manager seash. Seash allows you to control the files running in sandboxes you control.
+
+```
+python seash.py
+```
+
+**Step 2. Log in with your key**
+
+Before logging in, you have to load your public and private keys. You can get the keys at the  [SeattleClearinghouse](https://seattleclearinghouse.poly.edu/) website. You need to make sure that you have two files, your public and private key. The name of each file is your ID and the extension of files are publickey and privatekey.
+For example, if your ID were john, the two files would be ```john.publickey``` and ```john.privatekey```.   These files must be placed in the directory where you run ```seash```.
+
+If you successfully logged in, you could notice that the prompt starts with you ID.
+
+```python
+!> loadkeys john
+!> as john
+john@ !>
+```
+
+**Step 3. Locate the resources (laptops, smartphones, etc.) you can use**
+
+This command will tell the shell to locate resources that have been assigned to your account through the SeattleClearinghouse website. In order to assign resources to your account, you must go to the SeattleClearinghouse website, log into your account and get more resources under the 'My VMs' tab.
+
+```python
+john@ !> browse
+
+Added targets: %1(10.0.1.1:1224:v9), %2(10.0.1.2:2888:v9)
+
+Added group 'browsegood' with 2 targets
+
+The command browse produced the output that shows resources(targets) you can control. 
+```
+
+In the first target %1(10.0.1.1:1224:v9), %1 is the alias of the target, 10.0.1.1 is IP address, 1224 is port number, and v9 is VM name. The VM is the partial portion of whole donated resources. It means that the donated resources could be one VM or divided and assigned to more than one person. 
+
+**Step 4. Access the resources(VMs)**
+
+```python
+john@ !> on browsegood
+```
+
+**Step 5. Run a program**
+
+In this case, the program named example.1.1.r2py is stored in the current directory. Note that the results will not be printed.
+
+```python
+john@browsegood !> upload example.1.1.r2py
+john@browsegood !> start example.1.1.r2py
+```
+**Step 6. Look up the result of the program executed**
+
+In order to see the output, run 'show log', as is done below:
+
+```python
+john@browsegood !> show log
+
+Log from '10.0.1.1:1224:v9':
+Hello World
+
+Log from '10.0.1.2:2888:v9':
+Hello World
+```
+
+**Step 7. Look up the information about the VMs you control**
+
+```python
+john@browsegood !> list
+
+ID Own       Name          Status          Owner Information
+%1  *   10.0.1.1:1224:v9 Terminated                               
+%2  *   10.0.1.2:2888:v9 Terminated        
+```
+
+**Step 8. Exit from Seash**
+
+```python
+john@browsegood !> exit
+```
+
+
+You can find more practical examples in the [EducationalAssignments/TakeHome Take home assignment] page.                
+-->
+
+
+### Another Hello World example (example 1.2)
+----
+[example.1.2.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.1.2.r2py)
+
+In this example, we'll wait for the user to browse a port we listen on. When the user browses our page, we'll display a hello world webpage and then exit. 
+
+```python
+def hello(ip, port, sockobj):
+  # Receive the browser's HTTP request header, but we'll ignore it
+  httpheader = sockobj.recv(512)
+  response_body = "<html><head><title>Hello World</title></head>\
+                <body><h1> Hello World! </h1></body></html>"
+  # Send a simple HTTP header before the actual HTML
+  sockobj.send("HTTP/1.1 200 OK\r\nContent-Length: " +
+    str(len(response_body)) + "\r\n\r\n" + response_body)
+  # close my connection with this user
+  sockobj.close()
+
+
+if len(callargs) > 1:
+  raise Exception("Too many call arguments")
+
+# Running remotely: whenever this vessel gets a connection
+# on its IPaddress:Clearinghouseport it'll call hello
+elif len(callargs) == 1:
+  port = int(callargs[0])
+  ip = getmyip()
+
+# Running locally: whenever we get a connection
+# on 127.0.0.1:12345 we'll call hello
+else:
+  port = 12345
+  ip = '127.0.0.1'
+
+server_socket = listenforconnection(ip, port)
+
+while True:
+  try:
+    ret_ip, ret_port, ret_socket = server_socket.getconnection()
+    hello(ret_ip, ret_port, ret_socket)
+
+  except SocketWouldBlockError:
+    sleep(0.1)
+```
+
+The initialize portion has two options.  If you run it locally, it says, wait for a connection on 127.0.0.1 (the "local" IP of the computer), port 12345, and when you get, it calls the function hello().
+
+```
+127.0.0.1 is a special IP address. 
+It is localhost and means this computer. It is used to access the computer currently used.
+```
+
+<!---
+Otherwise, you're running it remotely and need to pass it your Clearinghouse port.  For convenience, Seattle Clearinghouse assigns the same UDP port to all of a user's VMs. To figure out which port you should use, log into the SeattleClearinghouse website and on the Profile page, look to see what port number it indicates. You'll see a page like below.
+
+
+![Seattle Clearinghouse](https://raw.githubusercontent.com/SeattleTestbed/docs/master/ATTACHMENTS/RepyV2Tutorial/clearinghouseport.png)
+
+You should write your Clearinghouseport down as you'll need this value repeatedly.
+-->
+The `listenforconnection()` function binds to an IP and port and waits for incoming TCP connections, and returns a `TCPServerSocket` object. 
+
+```
+TCP Server Socket = listenforconnection(IP address, Port number)
+
+IP address: IP address to listen on 
+Port number: The port to bind to
+TCP Server Socket: A way to obtain incoming connections
+
+```
+
+To read more about `listenforconnection()`, visit the [API](https://github.com/SeattleTestbed/docs/blob/master/Programming/RepyV2API.md)
+
+The `getconnection()` function receives a connection that was initiated to an IP and port, and returns a tuple containing: (remote ip, remote port, socket object). You can pass the returned socket object to other functions to do operations. For example, when you want to send some data to the remote host you can call `send()`, and you can close this connection by calling `close()`. 
+
+```
+Remote IP, Remote Port, Socket Object = server_socket.getconnection()
+
+Socket Object: End-point of a bidirectional communication flow across the Internet.
+
+```
+
+To read more about `getconnection()`, also visit the [API](https://github.com/SeattleTestbed/docs/blob/master/Programming/RepyV2API.md)
+
+The function `hello()` sends the webpage (the text in quotes) using the sockobj and then closes the current connection.
+
+``` 
+hello(IP address, Port number, Socket Object)
+
+The IP address and port the users are connecting to.
+
+```
+
+**Running locally**
+
+To run this program locally, you can type like below.
+
+```
+python repy.py restrictions.test example.1.2.r2py
+```
+
+Then open a web browser and in the address bar type: http://127.0.0.1:12345  (this says, navigate to the "local" IP of the computer at port 12345). You should see the hello world webpage.
+
+To stop the program, press CTRL-C.
+
+**Running remotely**
+
+*Todo: Use Sensibility Custom Installer?*
+
+<!---
+Open seash the same as in the previous example but choose a single VM.
+
+```python
+default@ !> on %1  
+default@%1 !>
+```
+
+Then, run this program passing it your Clearinghouse port.
+
+```python
+default@%1 !> upload example.1.2.r2py
+default@%1 !> start example.1.2.r2py Clearinghouseport
+default@%1 !> list                            
+  ID   Own                  Name                Status      Owner Information
+  %1             IP address:port:VMname     Started     
+```
+
+Notice that the program is "Started" instead of "Terminated". It's still running! 
+
+Now open a web browser and in the address bar type: IP_of_%1:Clearinghouseport.  For example, if 1.2.3.4 is the IP address of %1, and your port is 54321 then open your browser and in the address bar type "http://1.2.3.4:54321". If the node doesn't respond, try again.    You should see the hello world webpage.
+
+To stop the program, in the shell type:
+
+```python
+default@%1 !> stop  # This will stop any programs that are still running...  
+default@%1 !> list                          
+  ID    Own                Name                Status          Owner Information
+  %1             IP address:port:VMname    Stopped   
+```
+
+Notice that the program is now "Stopped".   It's not running
+
+-->
+
+### Counting the number of calls (example 1.3)
+----
+[example.1.3.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.1.3.r2py)
+
+
+In this example, we'll add a counter to our helloworld program. First we'll try some perfectly valid python code that will **NOT WORK** in Repy.
+
+```python
+def hello(ip, port, sockobj):  
+  global pagecount   # GLOBALS ARE NOT ALLOWED IN REPY
+  pagecount = pagecount + 1
+  httpheader = sockobj.recv(512) # Receive HTTP header, but we'll ignore it
+  response = ("<html><head><title>Hello World</title></head>"
+              "<body><h1> Hello World!</h1>"
+              "<p>You are visitor "+str(pagecount)+"</body></html>")
+  response = ('HTTP/1.1 200 OK\nContent-Type: text/html\nContent-Length: '+
+              str(len(response))+'\nServer: Seattle Testbed\n\n'+response)
+  sockobj.send(response)
+  # close my connection with this user
+  sockobj.close()
+
+mycontext['pagecount'] = 0
+
+if len(callargs) > 1:
+  raise Exception("Too many call arguments")
+
+# Running remotely: whenever this VM gets a connection 
+# on its IPaddress:Clearinghouseport it'll call hello
+elif len(callargs) == 1:
+  port = int(callargs[0])
+  ip = getmyip()
+
+# Running locally: whenever we get a connection
+# on 127.0.0.1:12345 we'll call hello
+else:
+  port = 12345
+  ip = '127.0.0.1'
+
+server_socket = listenforconnection(ip, port)
+
+while True:
+  try:
+    ret_ip, ret_port, ret_socket = server_socket.getconnection()
+    hello(ret_ip, ret_port, ret_socket)    
+  except SocketWouldBlockError:
+    sleep(0.1)
+```
+
+This code will not work because globals do not exist in Repy. However, there is a mycontext dictionary provided for this purpose. The code can be written as follows:
+
+```python
+def hello(ip, port, sockobj):
+  httpheader = sockobj.recv(512) # Receive HTTP header, but we'll ignore it
+  mycontext['pagecount'] = mycontext['pagecount'] + 1
+
+  response = ("<html><head><title>Hello World</title></head>"
+              "<body><h1> Hello World!</h1>"
+              "<p>You are visitor "+str(mycontext['pagecount'])+"</body></html>")
+  response = ('HTTP/1.1 200 OK\nContent-Type: text/html\nContent-Length: '+
+              str(len(response))+'\nServer: Seattle Testbed\n\n'+response)
+  sockobj.send(response)
+  # close my connection with this user
+  sockobj.close()
+
+mycontext['pagecount'] = 0
+
+if len(callargs) > 1:
+  raise Exception("Too many call arguments")
+
+# Running remotely: whenever this VM gets a connection
+# on its IPaddress:Clearinghouseport it'll call hello
+elif len(callargs) == 1:
+  port = int(callargs[0])
+  ip = getmyip()
+
+# Running locally: whenever we get a connection
+# on 127.0.0.1:12345 we'll call hello
+else:
+  port = 12345
+  ip = '127.0.0.1'
+
+server_socket = listenforconnection(ip, port)
+
+while True:
+  try:
+    ret_ip, ret_port, ret_socket = server_socket.getconnection()
+    hello(ret_ip, ret_port, ret_socket)
+  except SocketWouldBlockError:
+    sleep(0.1)
+```
+
+Start the program using the shell, then open a web browser and in the address bar type: http://127.0.0.1:12345/.  You should see the hello world webpage and a count of 1. You can refresh the page and the count should increment. Once again, use the shell to stop the program. *Note: Some web browsers might make two requests each time you reload, so don't worry if your counter increments faster than you would expect.*
+
+### Adding a Timer and listing the elapsed time (example 1.4)
+----
+[example.1.4.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.1.4.r2py)
+
+The previous program would run forever, waiting for a user to connect so it could display a webpage.   What if you wanted the program to stop running after 1 minute?   To do this, we'll register a timer that will close the connection.
+
+```python
+def hello(ip, port, sockobj):
+  try:
+    httpheader = sockobj.recv(512) # Receive HTTP header, but we'll ignore it
+  except SocketWouldBlockError:
+    sockobj.close()
+    return
+  mycontext['pagecount'] = mycontext['pagecount'] + 1
+  response = ("<html><head><title>Hello World</title></head>"
+              "<body><h1> Hello World!</h1>"
+              "<p>You are visitor "+str(mycontext['pagecount'])+"</body></html>")
+
+  response = ('HTTP/1.1 200 OK\nContent-Type: text/html\nContent-Length: '+
+              str(len(response))+'\nServer: Seattle Testbed\n\n'+response)
+  sockobj.send(response)
+  # close my connection with this user
+  sockobj.close()
+
+
+def close_after(t):
+  def sleep_for():
+    # after sleeping t sec, close the server
+    sleep(t)
+    exitall()
+  return sleep_for
+
+
+mycontext['pagecount'] = 0
+
+if len(callargs) > 1:
+  raise Exception("Too many call arguments")
+
+# Running remotely: whenever this vessel gets a connection
+# on its IPaddress:Clearinghouseport it'll call hello
+elif len(callargs) == 1:
+  port = int(callargs[0])
+  ip = getmyip()
+
+# Running locally: whenever we get a connection
+# on 127.0.0.1:12345 we'll call hello
+else:
+  port = 12345
+  ip = '127.0.0.1'
+
+server_socket = listenforconnection(ip, port)
+close_server = close_after(60)
+createthread(close_server)
+
+while True:
+  try:
+    ret_ip, ret_port, ret_socket = server_socket.getconnection()
+    hello(ret_ip, ret_port, ret_socket)
+  except SocketWouldBlockError:
+    sleep(0.1)
+  except SocketClosedLocal:
+    log("The server is going to close now!\n")
+    break
+```
+ 
+
+The timer (when called) will stop the communication. `settimer` returns an `eventhandle`. An `eventhandle` is similar to a `commhandle` in that it can be used to interact with an event. `listencommhandle` is not the arguments of settimer but that of `stop_listening`. The comma next to `stop_listening` and parentheses surrounding `listencommhandle` indicate that.
+
+`getruntime()` is used to provide the amount of time that has elapsed since the program was started.   Note that it may be possible for the elapsed time to be > 60 seconds in this program because there may be some lag between when the program started and when your code ran or a delay in running the `stop_listening` event.
+
+Start the program and then open a web browser and in the address bar type: http://127.0.0.1:12345/.  You'll notice that the webpage displays and after 1 minute the program will stop listening and stop itself.   <!--You'll see that the program's status is "Terminated" because it caused itself to exit (as opposed to "Stopped" where you stopped it while it was running). -->
+
+
+<!--
+### Interacting with Timers (example 1.5)
+[example.1.5.repy](https://github.com/SeattleTestbed/tutorial/blob/master/example/example.1.5.repy)
+----
+
+We know how to set a timer to close the connection in 60 seconds, but that doesn't help us to keep the connection open. To have the connection kept open while requests continue to happen, every time we get a request we'll cancel the existing timer and set a new timer for 10 seconds in the future that will close the connection. The timer(when called) will stop the communication. canceltimer stops a timer (if it hasn't already started).
+
+[[Image(SetTimer.jpg)]]
+
+```python
+def hello(ip,port,sockobj, thiscommhandle,listencommhandle):
+  httpheader = sockobj.recv(512) # Receive HTTP header, but we'll ignore it
+  mycontext['pagecount'] = mycontext['pagecount'] + 1
+  sockobj.send("<html><head><title>Hello World</title></head>
+
+                <body><h1> Hello World!</h1>
+
+                <p>You are visitor "+str(mycontext['pagecount'])+"</body></html>")
+  stopcomm(thiscommhandle)   # close my connection with this user
+
+  # stop the previous timer...
+  canceltimer(mycontext['stopevent'])
+
+  # start a new one for 10 seconds from now...
+  eventhandle = settimer(10, stop_listening, (listencommhandle,))
+  mycontext['stopevent'] = eventhandle
+ 
+def stop_listening(commhandle):
+  stopcomm(commhandle)   # this will deregister hello
+
+if callfunc == 'initialize':
+  mycontext['pagecount'] = 0
+
+  if len(callargs) > 1:
+    raise Exception("Too many call arguments")
+
+  # Running remotely:
+  # whenever this VM gets a connection on its IPaddress:Clearinghouseport it'll call hello
+  elif len(callargs) == 1:
+    port = int(callargs[0])
+    ip = getmyip()
+
+  # Running locally:
+  # whenever we get a connection on 127.0.0.1:12345 we'll call hello
+  else:
+    port = 12345
+    ip = '127.0.0.1'
+  listencommhandle = waitforconn(ip,port,hello)
+
+  eventhandle = settimer(10, stop_listening, (listencommhandle,))
+  mycontext['stopevent'] = eventhandle
+
+
+Try running the program and then try browsing the webpage a few times and then wait. You'll notice the connection closes 10 seconds after you stop browsing. 
+
+### Races, Sleep, and Locks (example 1.6)
+----
+[example.1.6.repy](https://github.com/SeattleTestbed/tutorial/blob/master/example/example.1.6.repy)
+
+
+The wily reader may have noticed that the previous program has a race condition. It is possible to have multiple browser windows browse 127.0.0.1 at the same time. It is possible for browser window A to cancel the timer, but before it adds the new eventhandle to mycontext!['stopevent'], window B could also try to cancel the timer and set up its own event. Now there are two events that will stop communications and only one of these will be listed in mycontext!['stopevent']. This means that regardless of how often a user views the webpages, the other event will fire because there is no reference to the eventhandle. The connection will be closed (not what we want!). It would be difficult to trigger this condition manually, but we'll use a command "sleep" to pause the current function for some amount of time to allow us to trigger the bug so that we can see it in practice.
+
+
+```python
+def hello(ip,port,sockobj, thiscommhandle,listencommhandle):
+  httpheader = sockobj.recv(512) # Receive HTTP header, but we'll ignore it
+  mycontext['pagecount'] = mycontext['pagecount'] + 1
+  sockobj.send("<html><head><title>Hello World</title></head>
+
+                <body><h1> Hello World!</h1>
+
+                <p>You are visitor "+str(mycontext['pagecount'])+"</body></html>")
+  stopcomm(thiscommhandle)   # close my connection with this user
+  canceltimer(mycontext['stopevent'])
+  sleep(5)   # give me 5 seconds to trigger the race
+  
+  # wait 10 seconds, then call stop_listening with listencommhandle
+  eventhandle = settimer(10, stop_listening, (listencommhandle,)) 
+  
+  mycontext['stopevent'] = eventhandle
+ 
+def stop_listening(commhandle):
+  stopcomm(commhandle)   # this will deregister hello
+
+if callfunc == 'initialize':
+  mycontext['pagecount'] = 0
+
+  if len(callargs) > 1:
+    raise Exception("Too many call arguments")
+
+  # Running remotely:
+  # whenever this VM gets a connection on its IPaddress:Clearinghouseport it'll call hello
+  elif len(callargs) == 1:
+    port = int(callargs[0])
+    ip = getmyip()
+
+  # Running locally:
+  # whenever we get a connection on 127.0.0.1:12345 we'll call hello
+  else:
+    port = 12345
+    ip = '127.0.0.1'
+  listencommhandle = waitforconn(ip,port,hello)
+
+  # wait 10 seconds, then call stop_listening with listencommhandle
+  eventhandle = settimer(10, stop_listening, (listencommhandle,)) 
+  
+  mycontext['stopevent'] = eventhandle
+```
+ 
+Try browsing the webpage a few times rapidly and then browse every 3-5 seconds.   You'll notice the program closes automatically even though it shouldn't (because you kept browsing).  
+
+One way to fix a race condition is using a lock. You can get a lock by calling getlock(). A lock supports two operations: acquire and release and is similar to the Python threading Lock class.
+
+We can avoid race conditions by the following changes:
+
+```python
+def hello(ip,port,sockobj, thiscommhandle,listencommhandle):
+  httpheader = sockobj.recv(512) # Receive HTTP header, but we'll ignore it
+  mycontext['pagecount'] = mycontext['pagecount'] + 1
+  sockobj.send("<html><head><title>Hello World</title></head>
+
+                <body><h1> Hello World!</h1>
+
+                <p>You are visitor "+str(mycontext['pagecount'])+"</body></html>")
+  stopcomm(thiscommhandle)   # close my connection with this user
+
+  mycontext['stoplock'].acquire() # acquire the lock
+
+  canceltimer(mycontext['stopevent'])
+  
+  # wait 10 seconds, then call stop_listening with listencommhandle
+  eventhandle = settimer(10, stop_listening, (listencommhandle,)) 
+  
+  mycontext['stopevent'] = eventhandle
+
+  mycontext['stoplock'].release() # release the lock
+ 
+def stop_listening(commhandle):
+  stopcomm(commhandle)   # this will deregister hello
+
+if callfunc == 'initialize':
+  mycontext['pagecount'] = 0
+  mycontext['stoplock'] = getlock()
+  
+  if len(callargs) > 1:
+    raise Exception("Too many call arguments")
+
+  # Running remotely:
+  # whenever this VM gets a connection on its IPaddress:Clearinghouseport it'll call hello
+  elif len(callargs) == 1:
+    port = int(callargs[0])
+    ip = getmyip()
+
+  # Running locally:
+  # whenever we get a connection on 127.0.0.1:12345 we'll call hello
+  else:
+    port = 12345
+    ip = '127.0.0.1'
+  listencommhandle = waitforconn(ip,port,hello)
+  
+  # wait 60 seconds, then call stop_listening with listencommhandle
+  eventhandle = settimer(10, stop_listening, (listencommhandle,)) 
+  
+  mycontext['stopevent'] = eventhandle
+```
+
+Now if you run the program repeatedly, it shouldn't be possible to trigger a race condition.   Note that since only one event can be in the section of the code protected with locks, if you put a sleep in there and rapidly browse, you may have your program slow down because there are not enough free threads / events.  
+
+Race conditions can happen with threads created by several different functions including waitforconn, recvmess, and settimer.   Remember that any callbacks or timers may be executing at the same time as your other code.   If you need to prevent multiple threads from modifying a variable or executing a piece of code at the same time, use a lock!
+
+-->
+
+## File Operations
+
+### Introduction to Files (example 2.1)
+----
+[example.2.1.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.2.1.r2py), [hello.file](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/hello.file)
+
+We'll now switch gears from our hello world web server and focus instead on writing data to files.   The first program we'll write the string "hello world" to a file and then read it back out and print it.
+
+```python
+# In repyV2 we use openfile(filename, create)
+# Boolean value decide whether creating file if such file doesn't exist
+myfileobject = openfile("hello.file", True)
+
+# Use fileobject.writeat(data, offset) to write data into file
+myfileobject.writeat("hello world\n", 0)
+
+myfileobject.close()
+
+newfileobject = openfile("hello.file", False)
+
+# Use fileobject.readat(sizelimit, offset) to read data from file
+myfilecontent = newfileobject.readat(None, 0)
+
+log(myfilecontent)
+newfileobject.close()
+```
+
+This program should print hello world (and an extra newline from '\n'). 
+
+
+### Listing and Removing Files (example 2.2)
+----
+[example.2.2.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.2.2.r2py)
+
+In this example, we'll change our program to write information to a few different files and after we're finished, we'll remove the files.   Instead of coding in the program which files to write information to, we'll let our command line arguments specify which files to write.
+
+```python
+for filename in callargs:   # callargs has all of the command line arguments in it.
+
+  myfileobject = openfile(filename, True)
+  myfileobject.writeat("hello world\n", 0)
+  myfileobject.close()
+
+  # Check the list of file names for files in the vessel by listfiles()
+  # This may include things other than our files.
+  myfilelist = listfiles()
+  log(myfilelist)
+
+for filename in callargs:   # let's remove our files now...
+  removefile(filename)
+
+log("\nThe files: " + str(callargs) + " should now be missing from " + str(listfiles()))
+```
+
+You should see output that first lists the file names in the current directory (along with the files you chose to write) and then shows the listing missing the files.   Note that if you choose file names with characters like "/", "\", "@", or other non-alphanumeric characters you will get an error because Repy programs are not allowed to use certain characters in file names.
+
+
+
+## Network Operations 1
+
+### Interacting with other computers (example 3.1)
+----
+[example.3.1.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.3.1.r2py)
+
+
+In this example, we'll retrieve a webpage and print it on the screen.   We're not going to translate all of the HTML or remove the HTTP headers, so it will be a bit messy.  
+
+```python
+# open a connection to the google web server
+destip = gethostbyname("www.google.com")
+socketobject = openconnection(destip, 80, getmyip(), 12345, 5)
+
+# this is a HTTP request...
+httprequest = "GET /index.html HTTP/1.1\r\nHost: www.google.com\r\n\r\n"
+socketobject.send(httprequest)
+
+while True:
+  try:
+    log(socketobject.recv(4096), "\n")
+  except SocketWouldBlockError:
+    sleep(0.1)
+  except SocketClosedRemote:
+    break
+```
+   
+You should see google's webpage along with some numbers and other information (this is the HTTP protocol).   However, the program does not stop (at least until you press CTRL-C)!   This is because HTTP 1.1 allows us to issue multiple page requests on a single connection.  
+
+### Causing a program to exit (example 3.2)
+----
+[example.3.2.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.3.2.r2py)
+
+In this example, we'll change the previous program to exit after we receive the data from google.   To do this we'll use a function called exitall().   This function causes the program to abort and all threads to exit immediately.   We can add this to a thread that sleeps for t seconds and then terminates, to the previous example as follows:
+
+```python
+def close_after(t):
+  def sleep_for():
+    # after sleeping t sec, terminate the program
+    sleep(t)
+    exitall()
+  return sleep_for
+
+# open a connection to the google web server
+destip = gethostbyname("www.google.com")
+socketobject = openconnection(destip, 80, getmyip(), 12345, 5)
+
+# this is a HTTP request...
+httprequest = "GET /index.html HTTP/1.1\r\nHost: www.google.com\r\n\r\n"
+socketobject.send(httprequest)
+
+terminate_program = close_after(10)
+createthread(terminate_program)
+
+while True:
+  try:
+    log(socketobject.recv(4096), "\n")
+  except SocketWouldBlockError:
+    sleep(0.1)
+  except SocketClosedRemote:
+    break
+```
+ 
+Alternatively, we could instead close the socket and check this condition.   Example code that shows this is below
+
+```python
+def close_after(t):
+  def sleep_for():
+    # after sleeping t sec, terminate the program
+    sleep(t)
+    socketobject.close() 
+  return sleep_for
+
+# open a connection to the google web server
+destip = gethostbyname("www.google.com")
+socketobject = openconnection(destip, 80, getmyip(), 12345, 5)
+  
+# this is a HTTP request...
+httprequest = "GET /index.html HTTP/1.1\r\nHost: www.google.com\r\n\r\n"
+socketobject.send(httprequest)
+
+terminate_program = close_after(10)
+createthread(terminate_program)
+  
+while True:
+  try:
+    log(socketobject.recv(4096), "\n")
+  except SocketWouldBlockError as e:
+    continue
+  except SocketClosedRemote as e:
+    break
+  except SocketClosedLocal as e:
+    break
+```
+
+## Network Operations 2
+### Looking up IP addresses (example 4.1)
+----
+[example.4.1.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.4.1.r2py)
+
+
+In this example, we'll look up some IP addresses using gethostname_ex:
+
+```python
+log(gethostbyname("www.google.com"), "\n")
+log(gethostbyname("www.wikipedia.com"), "\n")
+log(getmyip(), "\n")
+```
+
+This will print IP address, hostname and other information for google and wikipedia and will also print the current computer's IP address.   For more information about the format of the data returned from gethostbyname see the [API](https://github.com/SeattleTestbed/docs/blob/master/Programming/RepyV2API.md).
+
+
+
+### Sending and receiving messages (example 4.2)
+----
+[example.4.2.r2py](https://raw.githubusercontent.com/SeattleTestbed/tutorial/master/example/example.4.2.r2py)
+
+
+In this example, we'll manually send a NTP (time) lookup message and print the raw data that is returned.   Rather than hard code a server into our program, we'll randomly choose a server from a list of publicly available time servers.   A lot of the complexity in this program comes with encoding and decoding NTP data.  
+
+
+```python
+dy_import_module_symbols("random.r2py")
+
+# See RFC 2030 (http://www.ietf.org/rfc/rfc2030.txt) for details about NTP
+# this unpacks the data from the packet and changes it to a float
+def convert_timestamp_to_float(timestamp):
+  integerpart = (ord(timestamp[0])<<24) + (ord(timestamp[1])<<16) + (ord(timestamp[2])<<8) + (ord(timestamp[3]))
+  floatpart = (ord(timestamp[4])<<24) + (ord(timestamp[5])<<16) + (ord(timestamp[6])<<8) + (ord(timestamp[7]))
+  return integerpart + floatpart / float(2**32)
+
+
+def decode_NTP_packet(ip, port, mess, sockobj):
+  log("From " + str(ip) + ":" + str(port) + ", I received NTP data.\n")
+  log("NTP Reference Identifier:", mess[12:16], '\n')
+  log("NTP Transmit Time (in seconds since Jan 1st, 1900):", convert_timestamp_to_float(mess[40:48]), '\n')
+  sockobj.close()
+
+timeservers = ["time-a.nist.gov", "time-b.nist.gov", "time-a.timefreq.bldrdoc.gov",
+               "time-b.timefreq.bldrdoc.gov", "time-c.timefreq.bldrdoc.gov",
+               "utcnist.colorado.edu", "time.nist.gov", "nist1.symmetricom.com",
+               "nist.netservicesgroup.com"]
+
+# choose a random time server from the list
+servername = timeservers[int(randomfloat()*len(timeservers))]
+log("Using: ", servername, '\n')
+serverip = gethostbyname(servername)
+
+# this sends a request, version 3 in "client mode"
+ntp_request_string = chr(27)+chr(0)*47
+
+ip = getmyip()
+port = 34612
+
+# binds to an IP and port and waits for incoming UDP messages
+udpserversocket = listenformessage(ip, port)
+
+sendmessage(serverip, 123, ntp_request_string, ip, port) # port 123 is used for NTP
+
+while True:
+  try:
+    remoteip, remoteport, message = udpserversocket.getmessage()
+    decode_NTP_packet(remoteip, remoteport, message, udpserversocket)
+  except SocketWouldBlockError:
+    sleep(0.1)
+  except SocketClosedLocal:
+    break
+```
+
+To run this program locally, you need to do 
+
+```python repy.py restrictions.test dylink.r2py example.4.2.r2py``` 
+
+on command line. The port allowed for NTP communication can be found in the restriction file where 
+
+```resource messport xxxxx   # use for getting an NTP update```
+
+This program will print the number of seconds since Jan 1st, 1900 from a time server. If you run the program multiple times, you'll see it chooses servers randomly from the timeservers list.  
+
+Getting the time from a synchronized time source is a handy thing to do (so this isn't bad code to repurpose for your code).   You shouldn't ask for the time repeatedly from the time servers though (they consider requests more frequent than 4 seconds apart to be a DoS attack).   You can ask once for a global reference time and then use getruntime to measure the elapsed time.
+
+## Resources
+
+In the previous section, we looked at restrictions, a mechanism for allowing or denying an action. These aren't adequate for many cases. For example, you can say a program can or cannot write files, but you cannot say that a program can only write 1MB worth of files.   This is where resources come in.   They put limits on the number of resources a program can consume.
+
+If you look at a restrictions / resources file, you'll see a bunch of lines like this:
+
+```python
+resource cpu .10
+resource memory 10000000   # 10 Million bytes
+resource diskused 10000000 # 10 MB
+resource events 10
+resource filewrite 10000
+resource fileread 10000
+resource filesopened 5
+resource insockets 5
+resource outsockets 5
+resource netsend 10000
+resource netrecv 10000
+resource loopsend 1000000
+resource looprecv 1000000
+resource lograte 30000
+resource random 100
+resource messport 12345
+resource messport 12346
+resource connport 12345
+```
+
+These lines specify the type and quantity of resources the program can consume.   Some resources like CPU, the netsend / recv rate, random number generation rate, etc. are for renewable resources.   Renewable resources are resources that replenish themselves over time.   For example, if your program is using too much CPU, it will be paused temporarily to allow other programs to run.    Trying to use too much of a renewable resource will cause a call to run slowly.
+
+Alternatively, other resources like memory, disk used, sockets, etc. are not renewable.   In other words, the resource has a hard limit and is does does not automatically replenish itself over time.   When you use too much of one of these resources, the call in your program which causes it to be over the limit may raise an exception or in some cases the program may be killed outright.  
+
+The restrictions lines (with call information) is obsolete for Repy V2 and is ignored.   The RepyV2SecurityLayers functionality is a replacement that improves upon the previous technology.
+
+## Conclusion
+
+This concludes a brief tour of the Repy V2 functionality.   This guide has covered all of the API calls for Repy V2.   For more detailed information see the Library Reference and the Resources and Restrictions guide.   You should now be able to build your own Repy applications that can run on hundreds of computers.   Good luck!

--- a/tractomd.py
+++ b/tractomd.py
@@ -1,0 +1,115 @@
+"""
+Transform trac wiki markup file(s) to GitHub markdown markup and write it to
+new file with .md extension
+
+Usage:
+  python tractomd.py <trac markup>.wiki ...
+
+!!!
+This is not a fully fledged converter! It only takes over some repetitive tasks.
+I strongly recommend to also compare both documents and adjust manually. See 
+reasons below.
+!!!
+
+On the one hand implementing an isolated trac syntax parser is not something you
+do in a couple of hours. The guys at trac seem to have been working on this
+for quite some time: https://trac.edgewall.org/wiki/WikiEngine
+
+Additionally, we want to seize the opportunity of this conversion, to 
+update the documentation, i.e. each document needs to be reviewed 
+manually anyways.
+
+Nevertheless, contribution to this collection of regexes are most definitely 
+appreciated.
+
+Following trac syntac elements are ignored: 
+ - discussion
+ - citation
+ - macros
+ - macro lists
+ - list escaping
+ - headings without closing `=`
+ - bold italic
+ - color
+ - underline (because there is no underline in md)
+ - escaping with preceding !
+ - monospace escaping: `{{{` or {{{`}}}
+ - list continuation
+ - table headers
+ - table row continuation
+ - complex tables
+ - table cell alignment
+ - embedded images
+ - wiki links
+ - special links
+"""
+
+import sys, os, re
+
+def main(argv):
+  for wiki_filename in argv:
+    if (os.path.isfile(wiki_filename) and wiki_filename.endswith(".wiki")):
+      md_filename = os.path.splitext(wiki_filename)[0] + ".md"
+
+      text = ""
+      with open(wiki_filename, "r") as wiki_file:
+        for line in wiki_file:
+          # HEADINGS
+          line = re.sub(r'(?m)^======\s+(.*?)\s+======\s*$', r'###### \1\n', line)
+          line = re.sub(r'(?m)^=====\s+(.*?)\s+=====\s*$', r'##### \1\n', line)
+          line = re.sub(r'(?m)^====\s+(.*?)\s+====\s*$', r'#### \1\n', line)
+          line = re.sub(r'(?m)^===\s+(.*?)\s+===\s*$', r'### \1\n', line)
+          line = re.sub(r'(?m)^==\s+(.*?)\s+==\s*$', r'## \1\n', line)
+          line = re.sub(r'(?m)^=\s+(.*?)\s+=\s*$', r'# \1\n', line)
+
+          # LINKS
+          line = re.sub(r'\[(https?://[^\s\[\]]+)\s([^\[\]]+)\]', r'[\2](\1)', line)
+          # Strip trac internal link escapes
+          line = re.sub(r'!([A-Z])', r'\1', line)
+
+          # EMPHASIS
+          line = re.sub(r' \'\'\'(.*?)\'\'\' ', r' **\1** ', line) # bold
+          line = re.sub(r' //(.*?)// ', r' *\1* ', line) # italic
+          line = re.sub(r'\^(.*?)\^', r'<sup>\1</sup>', line) # superscript
+          line = re.sub(r',,(.*?),,', r'<sub>\1</sub>', line) # subscript
+
+          # MONOSPACE
+          line = re.sub(r'\{\{\{(.*?)\n?\}\}\}', r'```\1```', line) # any code
+
+          # LISTS
+          line = re.sub(r'^(\s*)a\. (\w.*?)$', r'\g<1>1. \2', line)
+          # Strip definition lists
+          line = re.sub(r'::', r'', line)
+
+          # TABLES
+          line = re.sub(r'\|\|', r'|', line)
+
+          # Strip TOC
+          line = re.sub(r'\[\[TOC\(inline\)\]\]', r'', line)
+
+          # LINEBREAKS
+          line = re.sub(r'\\', r'\n', line)
+          line = re.sub(r'\[\[BR\]\]', r'\n', line)
+
+          text += line
+
+        # Multiline replacing 
+        # CODE
+        # http://stackoverflow.com/questions/4823468/comments-in-markdown
+        comments = re.compile(r'\{\{\{\s*#!comment(.*?)\}\}\}', re.DOTALL)
+        text = re.sub(comments, r'<!--\1-->', text)
+
+        language = re.compile(r'\{\{\{\s*#!(\w*)(.*?)\}\}\}', re.DOTALL)
+        text = re.sub(language, r'```\1\2```', text)
+
+        anycode = re.compile(r'\{\{\{(.*?)\}\}\}', re.DOTALL)
+        text = re.sub(anycode, r'```\1```', text)
+
+
+      with open(md_filename, "w") as md_file:
+        md_file.write(text)
+
+if __name__ == '__main__':
+  main(sys.argv[1:])
+
+


### PR DESCRIPTION
Start converting trac wiki markup to github markdown markup. There is more to come, see issue #4 

This PR adds a script 'tractomd.py" for some automatic markup translation and also completely translates two pages RepyV2Tutorial and RepyV2API to markdown and updates them see [Repy V2 issue #108](https://github.com/SeattleTestbed/repy_v2/issues/108).

- updates file references to GitHub repos
- updates commands and code snippets
- comments out the remote experiment parts, because AFAIK there is no actual V2 clearinghouse to this date. We could reference to the Sensibility clearinghouse though, but this might confuse people new to the project.
- fully comments out timer and race condition experiments that where already partially commented out in trac, probably because the code has not yet been ported to V2.
