### PR TITLE
TEST_TARGET_DIR must be inside build.py's PWD

### DIFF
--- a/Contributing/BuildInstructions.md
+++ b/Contributing/BuildInstructions.md
@@ -103,8 +103,8 @@ unit test files. You just need to run the build script again to create a
 testable build. Use the `-t` command line option to indicate you want 
 the test files to be included. Again, specifying a target directory is optional!
 ```sh
-$ mkdir TEST_TARGET_DIR
 $ cd COMPONENT/scripts
+$ mkdir TEST_TARGET_DIR
 $ python build.py -t TEST_TARGET_DIR
 ```
 


### PR DESCRIPTION
Previously, the instructions suggest to create a TEST_TARGET_DIR inside COMPONENT, and then to cd into `/scripts` and run `build.py`. The `build.py` script looks for a TEST_TARGET_DIR  from where it is run, however, so if running from `/scripts`, the TEST_TARGET_DIR should be made inside `/scripts` .