### PR TITLE
Updating the instructions

### DIFF
--- a/EducationalAssignments/ParityPartOne.md
+++ b/EducationalAssignments/ParityPartOne.md
@@ -93,7 +93,7 @@ for details.
 Once you have built RepyV2 into a directory of your choice, change into that
 directory. Use the command below in order to run your RepyV2 programs:
 
-```python repy.py restrictions.default encasementlib.r2py initialfilelength.r2py [security_layer].r2py [program].r2py```
+```python repy.py restrictions.default encasementlib.r2py [security_layer].r2py [program].r2py```
 
 (Replace `[security_layer].r2py` and `[program].r2py` by the names of the
 security layers and program that you want to run.) 
@@ -315,16 +315,6 @@ done with the following command at the terminal:
  * In repy log replaces print from python.  This may be helpful when
 testing if Repy installed correctly.
 
-
-# Extra Credit
-----
-For extra credit, program that keeps all old versions of files and allows
-read from any of them.  Writing to any old file creates a new (empty) version
-of that file.
-Do not submit this code inside your assignment. Submit a separate copy for extra credit.
-
-
-
 # What to turn in?
 ----
  * Turn in a repy file called reference_monitor_[ netid ].r2py with all
@@ -332,5 +322,3 @@ letters in lowercase.
 
 * **Never raise unexpected errors or produce any output.**  Your program
 must produce no output when run normally.
-
- * For extra credit turn in a second repy file called extra_credit_[netid].r2py  **You must turn in separate files for the normal assignment and extra credit**


### PR DESCRIPTION
removed 'initialfilelength.r2py' from the command in line 96

removed information/instructions regarding the extra credit.

Instructions on how to run the Repy program is mentioned twice at line 96 and also at 291. I have retained both.