### PR TITLE
FIXED: Lost instruction

### DIFF
--- a/EducationalAssignments/ABStoragePartOne.md
+++ b/EducationalAssignments/ABStoragePartOne.md
@@ -29,7 +29,7 @@ the first or last characters, then the file is considered invalid.
 Applications use ABopenfile() to create or open a file. Files are created by 
 setting create=True when calling ABopenfile(), the reference 
 monitor will create a valid backup file called filename.a and an empty 
-file we will write to called filename.b. When close() is called on the file, if both filename.a and filename.b are valid, the original file's data is replaced with the data of filename.b. If filename.b is not valid, no changes are made. 
+file we will write to called filename.b. When close() is called on the file, if both filename.a and filename.b are valid, the original file's data is replaced with the data of filename.b. If filename.b is not valid, the original file should take on the data of the backup a file. Afterward both the a and b file are discarded. 
 
 Write test applications to ensure your reference monitor behaves properly 
 in different cases and to test attacks against your monitor.    

--- a/EducationalAssignments/ABStoragePartOne.md
+++ b/EducationalAssignments/ABStoragePartOne.md
@@ -29,7 +29,7 @@ the first or last characters, then the file is considered invalid.
 Applications use ABopenfile() to create or open a file. Files are created by 
 setting create=True when calling ABopenfile(), the reference 
 monitor will create a valid backup file called filename.a and an empty 
-file we will write to called filename.b. When close() is called on the file, if both filename.a and filename.b are valid, the original file's data is replaced with the data of filename.b. If filename.b is not valid, the original file should take on the data of the backup a file. Afterward both the a and b file are discarded. 
+file we will write to called filename.b. When close() is called on the file, if both filename.a and filename.b are valid, the original file's data is replaced with the data of filename.b. If filename.b is not valid, the original file should use the data of the backup filename.a file. Afterward both the filename.a and filename.b file should be deleted, and only the original file should remain. 
 
 Write test applications to ensure your reference monitor behaves properly 
 in different cases and to test attacks against your monitor.    


### PR DESCRIPTION
I noticed somewhere along the way we lost the instruction to discard the backup and write to file after changes are saved to the original file. 
This also helps to clarify what the original file is, as if the a and b files are both discarded then they cannot be the original file